### PR TITLE
Add simple front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,6 @@ Start the API:
 python -m src
 ```
 
-This will launch a FastAPI server on `http://localhost:8000` with an endpoint `/process/` that accepts `turbines` and `obstacles` files.
+This will launch a FastAPI server on `http://localhost:8000`.
+Open `http://localhost:8000` in your browser to use the interactive interface for uploading turbine and obstacle files.
+The interface sends the files to the `/process/` endpoint and displays the resulting map and crossing counts.

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 import geopandas as gpd
 from pathlib import Path
 import tempfile
@@ -7,6 +9,15 @@ from .workflow import create_extent, download_osm_layer, merge_layers, buffer_an
 from .crossings import load_osm_roads, load_osm_powerlines, count_crossings
 
 app = FastAPI()
+
+static_dir = Path(__file__).resolve().parent / "static"
+app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def root():
+    index_path = static_dir / "index.html"
+    return index_path.read_text()
 
 
 @app.post("/process/")

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Cabling Processor</title>
+<style>
+body{font-family:Arial, sans-serif; margin:2rem;}
+label{display:block;margin-top:1rem;}
+#map-container{margin-top:2rem;}
+</style>
+</head>
+<body>
+<h1>Cabling Processor</h1>
+<form id="upload-form">
+<label>Turbines file: <input type="file" id="turbines" name="turbines" required></label>
+<label>Obstacles file: <input type="file" id="obstacles" name="obstacles" required></label>
+<button type="submit">Process</button>
+</form>
+<div id="results"></div>
+<div id="map-container"></div>
+<script>
+const form = document.getElementById('upload-form');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const formData = new FormData();
+  formData.append('turbines', document.getElementById('turbines').files[0]);
+  formData.append('obstacles', document.getElementById('obstacles').files[0]);
+  document.getElementById('results').textContent = 'Processing...';
+  const response = await fetch('/process/', { method: 'POST', body: formData });
+  if (!response.ok) {
+    document.getElementById('results').textContent = 'Error processing files';
+    return;
+  }
+  const data = await response.json();
+  const kmzBlob = new Blob([Uint8Array.from(Buffer.from(data.kmz, 'hex'))], {type: 'application/vnd.google-earth.kmz'});
+  const kmzUrl = URL.createObjectURL(kmzBlob);
+  const downloadLink = `<a href="${kmzUrl}" download="obstacles.kmz">Download KMZ</a>`;
+  document.getElementById('results').innerHTML = `Road crossings: ${data.road_crossings}<br>Power crossings: ${data.power_crossings}<br>${downloadLink}`;
+  document.getElementById('map-container').innerHTML = data.map;
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make a basic upload page served by FastAPI
- serve static assets from FastAPI
- update README with instructions for using the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bea66a888321af2fdcb335aab402