### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ This repository provides utilities for replicating a QGIS workflow in Python and
 
 ### Running locally
 
-Install the dependencies (requires Python 3.11). The `requirements.txt` file includes
-`python-multipart`, which FastAPI needs to handle file uploads:
+Clone the repository and install the dependencies (requires Python 3.11). The
+`requirements.txt` file includes `python-multipart`, which FastAPI needs to
+handle file uploads. If you use a virtual environment, activate it before
+installing the packages.
 
 ```bash
+git clone <repo-url>
+cd Cabling
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
- clarify quickstart instructions for cloning and running the API locally

## Testing
- `pip install -r requirements.txt`
- `timeout 5 python -m src`

------
https://chatgpt.com/codex/tasks/task_e_6853d57b5014832198a36a5b0caaf0cc