### PR TITLE
Remove KMZ export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository provides utilities for replicating a QGIS workflow in Python and
 - **Workflow functions** (`src/workflow.py`)
   - Download OSM layers inside an extent
   - Merge and buffer obstacles
-  - Export KMZ and Folium maps
+  - Export Folium maps
 - **Crossing utilities** (`src/crossings.py`)
   - Load road and power line data from OSM
   - Count the number of crossings with a cable route
 - **Web API** (`src/app.py`)
   - Upload turbine and obstacle files (e.g., GeoPackage)
-  - Generate combined obstacle layers and return KMZ/Folium map
+  - Generate combined obstacle layers and return a Folium map
   - Report road and power line crossing counts
 
 ### Running locally

--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,7 @@ import geopandas as gpd
 from pathlib import Path
 import tempfile
 
-from .workflow import create_extent, download_osm_layer, merge_layers, buffer_and_union, export_kmz, export_folium_map
+from .workflow import create_extent, download_osm_layer, merge_layers, buffer_and_union, export_folium_map
 from .crossings import load_osm_roads, load_osm_powerlines, count_crossings
 
 app = FastAPI()
@@ -39,15 +39,12 @@ async def process_files(turbines: UploadFile = File(...), obstacles: UploadFile 
         obstacles_combined = merge_layers([obstacle_gdf, roads, power])
         obstacle_union = buffer_and_union(obstacles_combined, 20)
 
-        kmz_path = Path(tmpdir) / "obstacles.kmz"
-        export_kmz(obstacle_union.to_frame(name="geometry"), kmz_path)
         map_path = Path(tmpdir) / "map.html"
         export_folium_map(obstacle_union.to_frame(name="geometry"), map_path)
 
         road_cross, power_cross = count_crossings(obstacle_union.to_frame(name="geometry"), roads, power)
 
         return {
-            "kmz": kmz_path.read_bytes().hex(),
             "map": map_path.read_text(),
             "road_crossings": road_cross,
             "power_crossings": power_cross,

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -32,10 +32,7 @@ form.addEventListener('submit', async (e) => {
     return;
   }
   const data = await response.json();
-  const kmzBlob = new Blob([Uint8Array.from(Buffer.from(data.kmz, 'hex'))], {type: 'application/vnd.google-earth.kmz'});
-  const kmzUrl = URL.createObjectURL(kmzBlob);
-  const downloadLink = `<a href="${kmzUrl}" download="obstacles.kmz">Download KMZ</a>`;
-  document.getElementById('results').innerHTML = `Road crossings: ${data.road_crossings}<br>Power crossings: ${data.power_crossings}<br>${downloadLink}`;
+  document.getElementById('results').innerHTML = `Road crossings: ${data.road_crossings}<br>Power crossings: ${data.power_crossings}`;
   document.getElementById('map-container').innerHTML = data.map;
 });
 </script>


### PR DESCRIPTION
## Summary
- stop generating a KMZ file in the API and return only the map and counts
- simplify frontend to display the map and counts with no download link
- adjust README features accordingly

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a888b92448321864fde56ca4ae908