### PR TITLE
Enhanced wind route planner interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ geopandas
 folium
 requests
 python-multipart
+PyYAML

--- a/src/app.py
+++ b/src/app.py
@@ -2,10 +2,21 @@ from fastapi import FastAPI, UploadFile, File
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 import geopandas as gpd
+from shapely.geometry import box
 from pathlib import Path
 import tempfile
 
-from .workflow import create_extent, download_osm_layer, merge_layers, buffer_and_union, export_kmz, export_folium_map
+from .workflow import (
+    create_extent,
+    download_osm_layer,
+    merge_layers,
+    buffer_and_union,
+    export_kmz,
+    export_folium_map,
+    csv_to_yaml,
+    load_csv_points,
+    generate_simple_route,
+)
 from .crossings import load_osm_roads, load_osm_powerlines, count_crossings
 
 app = FastAPI()
@@ -21,33 +32,67 @@ async def root():
 
 
 @app.post("/process/")
-async def process_files(turbines: UploadFile = File(...), obstacles: UploadFile = File(...)):
+async def process_files(
+    turbines: UploadFile = File(...),
+    substation: UploadFile = File(...),
+    obstacles: UploadFile = File(...),
+):
+    """Process uploaded files and return YAML strings, KMZ route and map."""
     with tempfile.TemporaryDirectory() as tmpdir:
         turbine_path = Path(tmpdir) / turbines.filename
+        sub_path = Path(tmpdir) / substation.filename
         obstacle_path = Path(tmpdir) / obstacles.filename
+
         with open(turbine_path, "wb") as f:
             f.write(await turbines.read())
+        with open(sub_path, "wb") as f:
+            f.write(await substation.read())
         with open(obstacle_path, "wb") as f:
             f.write(await obstacles.read())
 
-        turbines_gdf = gpd.read_file(turbine_path)
+        turbines_gdf = load_csv_points(turbine_path)
+        substation_gdf = load_csv_points(sub_path)
         obstacle_gdf = gpd.read_file(obstacle_path)
 
+        # create YAML outputs
+        turbine_yaml = Path(tmpdir) / "turbines.yaml"
+        substation_yaml = Path(tmpdir) / "substation.yaml"
+        csv_to_yaml(turbine_path, turbine_yaml)
+        csv_to_yaml(sub_path, substation_yaml)
+
+        # extent layer
         extent = create_extent(turbines_gdf)
+        extent_gdf = gpd.GeoDataFrame(geometry=[box(*extent)], crs=4326)
+
+        # obstacles processing similar to original example
         roads = load_osm_roads(extent)
         power = load_osm_powerlines(extent)
         obstacles_combined = merge_layers([obstacle_gdf, roads, power])
         obstacle_union = buffer_and_union(obstacles_combined, 20)
 
-        kmz_path = Path(tmpdir) / "obstacles.kmz"
-        export_kmz(obstacle_union.to_frame(name="geometry"), kmz_path)
-        map_path = Path(tmpdir) / "map.html"
-        export_folium_map(obstacle_union.to_frame(name="geometry"), map_path)
+        # simple route generation
+        route_gdf = generate_simple_route(turbines_gdf, substation_gdf)
 
-        road_cross, power_cross = count_crossings(obstacle_union.to_frame(name="geometry"), roads, power)
+        kmz_path = Path(tmpdir) / "route.kmz"
+        export_kmz(route_gdf, kmz_path)
+
+        # build map with all layers
+        map_layers = {
+            "Turbines": turbines_gdf,
+            "Substation": substation_gdf,
+            "Obstacles": obstacle_gdf,
+            "Route": route_gdf,
+            "Extent": extent_gdf,
+        }
+        map_path = Path(tmpdir) / "map.html"
+        export_folium_map(map_layers, map_path)
+
+        road_cross, power_cross = count_crossings(route_gdf, roads, power)
 
         return {
-            "kmz": kmz_path.read_bytes().hex(),
+            "turbine_yaml": turbine_yaml.read_text(),
+            "substation_yaml": substation_yaml.read_text(),
+            "route_kmz": kmz_path.read_bytes().hex(),
             "map": map_path.read_text(),
             "road_crossings": road_cross,
             "power_crossings": power_cross,

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -2,40 +2,55 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Cabling Processor</title>
+<title>Wind Route Planner</title>
 <style>
-body{font-family:Arial, sans-serif; margin:2rem;}
+body{font-family:Arial, sans-serif;margin:0;padding:0;text-align:center;}
+#landing{background:url('https://images.unsplash.com/photo-1587502536263-3e7a834f8752?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;height:300px;display:flex;align-items:center;justify-content:center;}
+#start-btn{padding:1rem 2rem;font-size:1.2rem;cursor:pointer;}
+#process{margin:2rem;display:none;}
 label{display:block;margin-top:1rem;}
 #map-container{margin-top:2rem;}
 </style>
 </head>
 <body>
-<h1>Cabling Processor</h1>
+<div id="landing">
+<button id="start-btn">Start Planning</button>
+</div>
+<div id="process">
+<h2>Upload Data</h2>
 <form id="upload-form">
-<label>Turbines file: <input type="file" id="turbines" name="turbines" required></label>
-<label>Obstacles file: <input type="file" id="obstacles" name="obstacles" required></label>
-<button type="submit">Process</button>
+<label>Wind turbines CSV: <input type="file" id="turbines" name="turbines" required></label>
+<label>Substation CSV: <input type="file" id="substation" name="substation" required></label>
+<label>Obstacles (GPKG): <input type="file" id="obstacles" name="obstacles" required></label>
+<button type="submit">Generate Route</button>
 </form>
-<div id="results"></div>
+<pre id="yaml-results"></pre>
 <div id="map-container"></div>
+</div>
 <script>
+document.getElementById('start-btn').addEventListener('click', () => {
+  document.getElementById('landing').style.display = 'none';
+  document.getElementById('process').style.display = 'block';
+});
 const form = document.getElementById('upload-form');
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const formData = new FormData();
   formData.append('turbines', document.getElementById('turbines').files[0]);
+  formData.append('substation', document.getElementById('substation').files[0]);
   formData.append('obstacles', document.getElementById('obstacles').files[0]);
-  document.getElementById('results').textContent = 'Processing...';
+  document.getElementById('yaml-results').textContent = 'Processing...';
   const response = await fetch('/process/', { method: 'POST', body: formData });
   if (!response.ok) {
-    document.getElementById('results').textContent = 'Error processing files';
+    document.getElementById('yaml-results').textContent = 'Error processing files';
     return;
   }
   const data = await response.json();
-  const kmzBlob = new Blob([Uint8Array.from(Buffer.from(data.kmz, 'hex'))], {type: 'application/vnd.google-earth.kmz'});
+  document.getElementById('yaml-results').textContent =
+    'Turbine YAML:\n' + data.turbine_yaml + '\n\nSubstation YAML:\n' + data.substation_yaml;
+  const kmzBlob = new Blob([Uint8Array.from(Buffer.from(data.route_kmz, 'hex'))], {type: 'application/vnd.google-earth.kmz'});
   const kmzUrl = URL.createObjectURL(kmzBlob);
-  const downloadLink = `<a href="${kmzUrl}" download="obstacles.kmz">Download KMZ</a>`;
-  document.getElementById('results').innerHTML = `Road crossings: ${data.road_crossings}<br>Power crossings: ${data.power_crossings}<br>${downloadLink}`;
+  document.getElementById('yaml-results').innerHTML += '\n<br><a href="' + kmzUrl + '" download="route.kmz">Download Route</a>';
   document.getElementById('map-container').innerHTML = data.map;
 });
 </script>


### PR DESCRIPTION
## Summary
- add YAML conversion and simple route utilities
- generate maps with multiple layers
- revamp `/process/` endpoint to handle turbines, substation and obstacles
- add start page with hero image and improved upload form
- include PyYAML in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a899f24dc832190a91a568367124a