### PR TITLE
Add script to build full site YAML

### DIFF
--- a/build_site_yaml.py
+++ b/build_site_yaml.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Command line helper to create a site YAML from turbine, substation and obstacle files."""
+import argparse
+from pathlib import Path
+import sys
+
+# allow running without installation
+sys.path.append(str(Path(__file__).resolve().parent / "src"))
+from workflow import build_site_yaml
+
+
+def main(turbine_file: str, substation_file: str, obstacles_gpkg: str, output_yaml: str) -> None:
+    build_site_yaml(Path(turbine_file), Path(substation_file), Path(obstacles_gpkg), Path(output_yaml))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create a site YAML from turbine Excel/CSV, substation KML/KMZ and obstacle GeoPackage")
+    parser.add_argument("turbine_file", help="Turbine Excel or CSV with UTM coordinates")
+    parser.add_argument("substation_file", help="Substation KML or KMZ")
+    parser.add_argument("obstacles_gpkg", help="Obstacle GeoPackage")
+    parser.add_argument("output_yaml", help="Output YAML path")
+    args = parser.parse_args()
+    main(args.turbine_file, args.substation_file, args.obstacles_gpkg, args.output_yaml)
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,6 +16,7 @@ from .workflow import (
     generate_optimized_route,
     gpkg_to_obstacles_yaml,
     gpkg_to_kmz,
+    build_site_yaml,
 )
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "generate_optimized_route",
     "gpkg_to_obstacles_yaml",
     "gpkg_to_kmz",
+    "build_site_yaml",
 ]


### PR DESCRIPTION
## Summary
- add `build_site_yaml` function to workflow utilities
- expose the new function from `cabling` package
- provide `build_site_yaml.py` CLI helper for creating site configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685da7084f90832195ccd62bfc87fd43