### PR TITLE
Add helper to generate full site YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ There is also a small command line wrapper ``turbines_to_extents.py``:
 ./turbines_to_extents.py turbines.yaml --out-dir temp
 ```
 
+### Create a full site YAML
+
+When you have turbine spreadsheets, a substation KML/KMZ and obstacle
+data, the ``full_yaml.py`` helper can assemble them into a single site
+definition:
+
+```bash
+./full_yaml.py turbines.xlsx substation.kmz obstacles.gpkg site.yaml
+```
+
+The script uses the same logic as the API to convert coordinates and
+produces ``site.yaml`` ready for optimisation.
+
 ### Quick map viewer
 
 Navigate to `/map` to access a simple viewer for plotting turbine and substation files on a Leaflet map. Upload turbine coordinates as `.xlsx`, `.csv`, or `.yaml` and optional substation data as `.kmz`. The `/upload` endpoint converts the data to GeoJSON and also returns a bounding-box layer when turbines are provided.

--- a/full_yaml.py
+++ b/full_yaml.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Create a complete site YAML from raw turbine, substation and obstacle data."""
+import argparse
+from pathlib import Path
+import sys
+
+# Allow running without installing the package
+sys.path.append(str(Path(__file__).resolve().parent / "src"))
+from workflow import build_site_yaml
+
+
+def main(turbine_file: Path, substation_file: Path, obstacles_gpkg: Path, output_yaml: Path) -> None:
+    """Generate ``output_yaml`` by combining all input files."""
+    build_site_yaml(turbine_file, substation_file, obstacles_gpkg, output_yaml)
+    print(f"Created site YAML at {output_yaml}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate a full site YAML from turbine, substation and obstacle files"
+    )
+    parser.add_argument("turbine_file", help="Turbine Excel or CSV with UTM coordinates")
+    parser.add_argument("substation_file", help="Substation KML or KMZ")
+    parser.add_argument("obstacles_gpkg", help="Obstacle GeoPackage")
+    parser.add_argument("output_yaml", help="Destination for the combined YAML")
+    args = parser.parse_args()
+
+    main(Path(args.turbine_file), Path(args.substation_file), Path(args.obstacles_gpkg), Path(args.output_yaml))


### PR DESCRIPTION
## Summary
- add `full_yaml.py` to create a combined site YAML from turbine, substation and obstacle data
- document usage in the README

## Testing
- `python -m py_compile full_yaml.py src/workflow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc53ffcd88321982ae41e41752300